### PR TITLE
fix: link to getting started and readme contrib steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,8 @@
 This project uses <https://docusaurus.io/> under the hood which is a documentation generator comprised of React and Markdown.
 
 1. Git clone this repository
-
-2. `yarn` install dependencies in the root directory
-
-3.`cd website` switch to the website directory
-
+3. `cd website` switch to the website directory
+2. `yarn` to install necessary dependencies 
 4. `yarn run start` start website server locally 
 
 ## Helpful Docusaurus Docs

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -37,7 +37,7 @@ class Footer extends React.Component {
           </a>
           <div>
             <h5>Docs</h5>
-            <a href={this.docUrl("start.html", this.props.language)}>
+            <a href={this.docUrl("start.html")}>
               Getting Started
             </a>
           </div>


### PR DESCRIPTION
fixed footer link to remove the language part of the slug

swapped steps in contrib guide as `package.json` is in the `website` dir in order to install docosaur